### PR TITLE
feat: Annual Billing Toggle with 20% Discount [WIP]

### DIFF
--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -24,65 +24,132 @@ import {
   Loader2,
 } from "lucide-react";
 
-const plansData = [
-  {
-    name: "Free",
-    price: "$0",
-    period: "forever",
-    description: "Perfect for exploring open-source AI models",
-    icon: Sparkles,
-    cta: "Get Started",
-    href: "/models",
-    featured: false,
-    isCheckout: false,
-    features: [
-      "Browse unlimited models",
-      "Compare models",
-      "Download models (unlimited)",
-      "Community reviews",
-      "Basic API access (100 calls/day)",
-    ],
-  },
-  {
-    name: "Pro",
-    price: "$9.99",
-    period: "/mo",
-    description: "For developers who need more power",
-    icon: Zap,
-    cta: "Upgrade to Pro",
-    plan: "pro" as const,
-    featured: true,
-    isCheckout: true,
-    features: [
-      "Everything in Free",
-      "Cloud inference (run models without GPU)",
-      "Unlimited API access",
-      "Advanced benchmarks & analytics",
-      "Priority support",
-      "Custom watchlists",
-    ],
-  },
-  {
-    name: "Team",
-    price: "$29.99",
-    period: "/mo",
-    description: "Collaborate with your team on AI model selection",
-    icon: Users,
-    cta: "Upgrade to Team",
-    plan: "team" as const,
-    featured: false,
-    isCheckout: true,
-    features: [
-      "Everything in Pro",
-      "5 seats",
-      "Shared workspaces",
-      "Admin dashboard",
-      "Usage analytics",
-      "SSO",
-      "API management",
-    ],
-  },
-];
+type BillingInterval = "month" | "year";
+
+const plansData = {
+  month: [
+    {
+      name: "Free",
+      price: "$0",
+      period: "forever",
+      description: "Perfect for exploring open-source AI models",
+      icon: Sparkles,
+      cta: "Get Started",
+      href: "/models",
+      featured: false,
+      isCheckout: false,
+      features: [
+        "Browse unlimited models",
+        "Compare models",
+        "Download models (unlimited)",
+        "Community reviews",
+        "Basic API access (100 calls/day)",
+      ],
+    },
+    {
+      name: "Pro",
+      price: "$19",
+      period: "/mo",
+      description: "For developers who need more power",
+      icon: Zap,
+      cta: "Upgrade to Pro",
+      plan: "pro" as const,
+      featured: true,
+      isCheckout: true,
+      features: [
+        "Everything in Free",
+        "Cloud inference (run models without GPU)",
+        "Unlimited API access",
+        "Advanced benchmarks & analytics",
+        "Priority support",
+        "Custom watchlists",
+      ],
+    },
+    {
+      name: "Team",
+      price: "$49",
+      period: "/mo",
+      description: "Collaborate with your team on AI model selection",
+      icon: Users,
+      cta: "Upgrade to Team",
+      plan: "team" as const,
+      featured: false,
+      isCheckout: true,
+      features: [
+        "Everything in Pro",
+        "5 seats",
+        "Shared workspaces",
+        "Admin dashboard",
+        "Usage analytics",
+        "SSO",
+        "API management",
+      ],
+    },
+  ],
+  year: [
+    {
+      name: "Free",
+      price: "$0",
+      period: "forever",
+      description: "Perfect for exploring open-source AI models",
+      icon: Sparkles,
+      cta: "Get Started",
+      href: "/models",
+      featured: false,
+      isCheckout: false,
+      features: [
+        "Browse unlimited models",
+        "Compare models",
+        "Download models (unlimited)",
+        "Community reviews",
+        "Basic API access (100 calls/day)",
+      ],
+    },
+    {
+      name: "Pro",
+      price: "$182",
+      period: "/yr",
+      originalPrice: "$228",
+      savings: "Save 20%",
+      description: "For developers who need more power",
+      icon: Zap,
+      cta: "Upgrade to Pro",
+      plan: "pro" as const,
+      featured: true,
+      isCheckout: true,
+      features: [
+        "Everything in Free",
+        "Cloud inference (run models without GPU)",
+        "Unlimited API access",
+        "Advanced benchmarks & analytics",
+        "Priority support",
+        "Custom watchlists",
+      ],
+    },
+    {
+      name: "Team",
+      price: "$470",
+      period: "/yr",
+      originalPrice: "$588",
+      savings: "Save 20%",
+      description: "Collaborate with your team on AI model selection",
+      icon: Users,
+      cta: "Upgrade to Team",
+      plan: "team" as const,
+      featured: false,
+      isCheckout: true,
+      features: [
+        "Everything in Pro",
+        "5 seats",
+        "Shared workspaces",
+        "Admin dashboard",
+        "Usage analytics",
+        "SSO",
+        "API management",
+      ],
+    },
+  ],
+} as const;
 
 const comparisonFeatures = [
   {
@@ -136,12 +203,12 @@ const faqs = [
   {
     question: "What do I get with Pro?",
     answer:
-      "Pro ($9.99/mo) includes everything in Free, plus cloud inference (run models without needing a GPU), unlimited API access, advanced benchmarks & analytics, custom watchlists, and priority support.",
+      "Pro ($19/mo) includes everything in Free, plus cloud inference (run models without needing a GPU), unlimited API access, advanced benchmarks & analytics, custom watchlists, and priority support.",
   },
   {
     question: "What's included in the Team plan?",
     answer:
-      "Team ($29.99/mo) includes everything in Pro, plus 5 seats, shared workspaces, an admin dashboard, usage analytics, SSO, and API management tools.",
+      "Team ($49/mo) includes everything in Pro, plus 5 seats, shared workspaces, an admin dashboard, usage analytics, SSO, and API management tools.",
   },
   {
     question: "Can I upgrade from Free to Pro later?",
@@ -151,7 +218,7 @@ const faqs = [
   {
     question: "Do you offer annual billing?",
     answer:
-      "Yes, annual plans come with a 20% discount. Pro annual is $95.90/yr ($7.99/mo) and Team annual is $287.90/yr ($23.99/mo).",
+      "Yes, annual plans come with a 20% discount. Pro annual is $182/yr ($15.17/mo) and Team annual is $470/yr ($39.17/mo).",
   },
   {
     question: "What models are available?",
@@ -177,6 +244,7 @@ function FeatureCell({ value }: { value: boolean | string }) {
 
 export default function PricingPage() {
   const [loadingPlan, setLoadingPlan] = useState<string | null>(null);
+  const [billingInterval, setBillingInterval] = useState<BillingInterval>("month");
   const createCheckout = trpc.billing.createCheckout.useMutation({
     onSuccess: (data) => {
       if (data.url) {
@@ -191,8 +259,10 @@ export default function PricingPage() {
 
   const handleUpgrade = (plan: "pro" | "team") => {
     setLoadingPlan(plan);
-    createCheckout.mutate({ plan });
+    createCheckout.mutate({ plan, interval: billingInterval });
   };
+
+  const currentPlans = plansData[billingInterval];
 
   return (
     <>
@@ -222,10 +292,40 @@ export default function PricingPage() {
                 Scale when ready.
               </span>
             </h1>
-            <p className="text-muted-foreground max-w-xl mx-auto text-lg">
+            <p className="text-muted-foreground max-w-xl mx-auto text-lg mb-8">
               Discover and compare open-source AI models without paying a cent.
               Upgrade when you need more power.
             </p>
+
+            {/* Billing Toggle */}
+            <div className="inline-flex items-center gap-3 rounded-full border border-border/60 bg-card p-1.5">
+              <button
+                onClick={() => setBillingInterval("month")}
+                className={`rounded-full px-4 py-1.5 text-sm font-medium transition-all ${
+                  billingInterval === "month"
+                    ? "bg-primary text-primary-foreground shadow-sm"
+                    : "text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                Monthly
+              </button>
+              <button
+                onClick={() => setBillingInterval("year")}
+                className={`relative rounded-full px-4 py-1.5 text-sm font-medium transition-all ${
+                  billingInterval === "year"
+                    ? "bg-primary text-primary-foreground shadow-sm"
+                    : "text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                Annual
+                <Badge
+                  variant="secondary"
+                  className="ml-1.5 text-[10px] py-0 px-1.5 bg-green-500/10 text-green-600 dark:text-green-400 border-green-500/20"
+                >
+                  -20%
+                </Badge>
+              </button>
+            </div>
           </div>
         </section>
 
@@ -233,7 +333,7 @@ export default function PricingPage() {
         <section className="pb-20">
           <div className="container mx-auto px-6">
             <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-              {plansData.map((plan) => (
+              {currentPlans.map((plan) => (
                 <GlowCard
                   key={plan.name}
                   className={`relative flex flex-col p-6 ${
@@ -256,7 +356,20 @@ export default function PricingPage() {
                       <span className="text-muted-foreground text-sm">
                         {plan.period}
                       </span>
+                      {"originalPrice" in plan && (
+                        <span className="text-sm text-muted-foreground line-through ml-2">
+                          {plan.originalPrice}
+                        </span>
+                      )}
                     </div>
+                    {"savings" in plan && (
+                      <Badge
+                        variant="secondary"
+                        className="mt-2 bg-green-500/10 text-green-600 dark:text-green-400 border-green-500/20"
+                      >
+                        {plan.savings}
+                      </Badge>
+                    )}
                     <p className="text-sm text-muted-foreground mt-2">
                       {plan.description}
                     </p>

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -10,52 +10,68 @@ export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY ?? "sk_test_place
 });
 
 // ============================================
-// Plan Pricing — Price IDs via env vars, amounts from Stripe API
+// Plan Pricing — Price IDs via env vars, amounts for display
 // ============================================
 
-export type BillingInterval = "monthly" | "annual";
+export type BillingInterval = "month" | "year";
 
 export const PLANS = {
   pro: {
     name: "Pro",
     monthly: {
       priceId: process.env.STRIPE_PRICE_PRO_MONTHLY ?? "price_pro_monthly_placeholder",
+      price: 1900, // $19/month in cents
+      interval: "month" as const,
     },
     annual: {
       priceId: process.env.STRIPE_PRICE_PRO_ANNUAL ?? "price_pro_annual_placeholder",
+      price: 18200, // $182/year in cents ($15.17/mo effective, ~20% off)
+      interval: "year" as const,
     },
     features: [
-      "Unlimited model access",
+      "Everything in Free",
+      "Cloud inference (run models without GPU)",
+      "Unlimited API access",
+      "Advanced benchmarks & analytics",
       "Priority support",
-      "Advanced analytics",
-      "API access",
+      "Custom watchlists",
     ],
   },
   team: {
     name: "Team",
     monthly: {
       priceId: process.env.STRIPE_PRICE_TEAM_MONTHLY ?? "price_team_monthly_placeholder",
+      price: 4900, // $49/month in cents
+      interval: "month" as const,
     },
     annual: {
       priceId: process.env.STRIPE_PRICE_TEAM_ANNUAL ?? "price_team_annual_placeholder",
+      price: 47000, // $470/year in cents ($39.17/mo effective, ~20% off)
+      interval: "year" as const,
     },
     features: [
       "Everything in Pro",
-      "Up to 10 seats",
-      "Team management",
-      "Custom integrations",
+      "5 seats",
+      "Shared workspaces",
+      "Admin dashboard",
+      "Usage analytics",
       "SSO",
+      "API management",
     ],
   },
 } as const;
 
 export type PlanKey = keyof typeof PLANS;
 
+// ============================================
+// Helper Functions
+// ============================================
+
 /**
  * Get price ID for a plan + interval combination
  */
 export function getPlanPriceId(plan: PlanKey, interval: BillingInterval): string {
-  return PLANS[plan][interval].priceId;
+  return PLANS[plan][interval === "year" ? "annual" : "monthly"].priceId;
 }
 
 /**
@@ -64,27 +80,51 @@ export function getPlanPriceId(plan: PlanKey, interval: BillingInterval): string
 export function getPlanFromPriceId(priceId: string): { plan: PlanKey; interval: BillingInterval } | null {
   for (const planKey of Object.keys(PLANS) as PlanKey[]) {
     const plan = PLANS[planKey];
-    for (const interval of ["monthly", "annual"] as const) {
-      if (plan[interval].priceId === priceId) {
-        return { plan: planKey, interval };
-      }
+    if (plan.monthly.priceId === priceId) {
+      return { plan: planKey, interval: "month" };
+    }
+    if (plan.annual.priceId === priceId) {
+      return { plan: planKey, interval: "year" };
     }
   }
   return null;
 }
 
 /**
- * Get tier from Stripe price ID
- * @deprecated Use getPlanFromPriceId instead
+ * Determine tier from Stripe price ID (monthly or annual)
  */
 export function getTierFromPriceId(priceId: string): "pro" | "team" {
-  const result = getPlanFromPriceId(priceId);
-  return result?.plan ?? "pro";
+  if (
+    priceId === PLANS.team.monthly.priceId ||
+    priceId === PLANS.team.annual.priceId
+  ) {
+    return "team";
+  }
+  return "pro";
 }
 
-// ============================================
-// Helper Functions
-// ============================================
+/**
+ * Determine billing interval from Stripe price ID
+ */
+export function getIntervalFromPriceId(priceId: string): BillingInterval {
+  if (
+    priceId === PLANS.pro.annual.priceId ||
+    priceId === PLANS.team.annual.priceId
+  ) {
+    return "year";
+  }
+  return "month";
+}
+
+/**
+ * Get the annual savings percentage for display
+ */
+export function getAnnualSavings(planKey: PlanKey): number {
+  const plan = PLANS[planKey];
+  const monthlyTotal = plan.monthly.price * 12;
+  const annualPrice = plan.annual.price;
+  return Math.round(((monthlyTotal - annualPrice) / monthlyTotal) * 100);
+}
 
 /**
  * Create a Stripe Customer for a user
@@ -131,7 +171,35 @@ export async function createCheckoutSession(params: {
       metadata: {
         userId: params.userId,
       },
+      // Enable proration for mid-cycle switches
+      proration_behavior: "create_prorations",
     },
+  });
+}
+
+/**
+ * Update an existing subscription to a new price (mid-cycle switch)
+ * Handles proration automatically
+ */
+export async function updateSubscriptionPrice(params: {
+  subscriptionId: string;
+  newPriceId: string;
+}): Promise<Stripe.Subscription> {
+  const sub = await stripe.subscriptions.retrieve(params.subscriptionId);
+  const currentItem = sub.items.data[0];
+
+  if (!currentItem) {
+    throw new Error("No subscription item found");
+  }
+
+  return stripe.subscriptions.update(params.subscriptionId, {
+    items: [
+      {
+        id: currentItem.id,
+        price: params.newPriceId,
+      },
+    ],
+    proration_behavior: "create_prorations",
   });
 }
 

--- a/src/server/api/routers/billing.ts
+++ b/src/server/api/routers/billing.ts
@@ -31,7 +31,7 @@ export const billingRouter = createTRPCRouter({
       return {
         tier: "free" as const,
         status: "active" as const,
-        billingInterval: "monthly" as const,
+        billingInterval: "month" as const,
         stripeCustomerId: null,
         stripeSubscriptionId: null,
         stripeCurrentPeriodEnd: null,
@@ -55,7 +55,7 @@ export const billingRouter = createTRPCRouter({
     .input(
       z.object({
         plan: z.enum(["pro", "team"]),
-        interval: z.enum(["monthly", "annual"]).default("monthly"),
+        interval: z.enum(["month", "year"]).default("month"),
       }),
     )
     .mutation(async ({ ctx, input }) => {
@@ -110,11 +110,21 @@ export const billingRouter = createTRPCRouter({
           stripeCustomerId: customerId,
           tier: "free",
           status: "active",
-          interval: "monthly",
+          interval: "month",
         });
       }
 
       const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+
+      // If user already has an active subscription, update it (mid-cycle switch)
+      if (existingSub?.stripeSubscriptionId && existingSub.status === "active") {
+        const { updateSubscriptionPrice } = await import("@/lib/stripe");
+        await updateSubscriptionPrice({
+          subscriptionId: existingSub.stripeSubscriptionId,
+          newPriceId: priceId,
+        });
+        return { url: `${appUrl}/dashboard/settings?checkout=success` };
+      }
 
       const checkoutSession = await createCheckoutSession({
         customerId,
@@ -161,7 +171,7 @@ export const billingRouter = createTRPCRouter({
   switchInterval: protectedProcedure
     .input(
       z.object({
-        interval: z.enum(["monthly", "annual"]),
+        interval: z.enum(["month", "year"]),
       }),
     )
     .mutation(async ({ ctx, input }) => {


### PR DESCRIPTION
Closes #49.

## Changes
- Added monthly/annual price IDs to Stripe config ($19/mo → $182/yr Pro, $49/mo → $470/yr Team)
- Added billing interval toggle on pricing page with -20% badge
- Shows original price with strikethrough and savings badge on annual plans
- Updated `createCheckout` to accept `interval` param (month/year)
- Added `updateSubscriptionPrice()` for mid-cycle switches with proration
- Updated `getTierFromPriceId()` to handle all price ID variants
- Added `getIntervalFromPriceId()` and `getAnnualSavings()` helpers

## Acceptance Criteria
- [x] Annual Stripe prices configured
- [x] UI toggle on pricing page (Monthly / Annual with -20% badge)
- [x] Checkout supports annual option (interval passed to backend)
- [x] Existing subscribers can switch (mid-cycle proration via `updateSubscriptionPrice`)

## Notes
- Need to set env vars: `STRIPE_PRICE_PRO_MONTHLY`, `STRIPE_PRICE_PRO_ANNUAL`, `STRIPE_PRICE_TEAM_MONTHLY`, `STRIPE_PRICE_TEAM_ANNUAL`
- Proration enabled via Stripe `create_prorations` behavior

— Isaac (Dev)