### PR TITLE
feat: trust score tRPC router enhancements (#43)

### DIFF
--- a/src/server/api/routers/trust-scores.ts
+++ b/src/server/api/routers/trust-scores.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
 import { createTRPCRouter, publicProcedure } from "../trpc";
 import { db } from "../../db";
-import { trustScore, model } from "../../db/schema";
-import { eq, desc, sql } from "drizzle-orm";
+import { trustScore, model, scoreSnapshot } from "../../db/schema";
+import { eq, desc, sql, and, gte } from "drizzle-orm";
 
 export const trustScoresRouter = createTRPCRouter({
   list: publicProcedure
@@ -13,6 +13,7 @@ export const trustScoresRouter = createTRPCRouter({
         sort: z
           .enum(["overall", "reliability", "consistency", "cost_efficiency"])
           .default("overall"),
+        provider: z.string().optional(),
       }),
     )
     .query(async ({ input }) => {
@@ -37,7 +38,14 @@ export const trustScoresRouter = createTRPCRouter({
         })
         .from(trustScore)
         .innerJoin(model, eq(trustScore.modelId, model.id))
-        .where(eq(trustScore.periodDays, input.periodDays))
+        .where(
+          input.provider
+            ? and(
+                eq(trustScore.periodDays, input.periodDays),
+                eq(trustScore.providerId, input.provider),
+              )
+            : eq(trustScore.periodDays, input.periodDays),
+        )
         .orderBy(
           input.sort === "overall"
             ? desc(trustScore.overallScore)
@@ -78,4 +86,58 @@ export const trustScoresRouter = createTRPCRouter({
 
       return { scores };
     }),
+
+  /**
+   * Get historical score snapshots for a model (chart data).
+   * Returns daily snapshots for score history visualization.
+   */
+  history: publicProcedure
+    .input(
+      z.object({
+        slug: z.string(),
+        days: z.number().min(1).max(365).default(30),
+        provider: z.string().optional(),
+      }),
+    )
+    .query(async ({ input }) => {
+      const [modelData] = await db
+        .select({ id: model.id })
+        .from(model)
+        .where(eq(model.slug, input.slug))
+        .limit(1);
+
+      if (!modelData) return { snapshots: [] };
+
+      const cutoff = new Date();
+      cutoff.setDate(cutoff.getDate() - input.days);
+
+      const conditions = [
+        eq(scoreSnapshot.modelId, modelData.id),
+        gte(scoreSnapshot.snapshotDate, cutoff),
+      ];
+      if (input.provider) {
+        conditions.push(eq(scoreSnapshot.providerId, input.provider));
+      }
+
+      const snapshots = await db
+        .select()
+        .from(scoreSnapshot)
+        .where(and(...conditions))
+        .orderBy(scoreSnapshot.snapshotDate);
+
+      return { snapshots };
+    }),
+
+  /**
+   * List distinct providers that have trust scores.
+   * Used for leaderboard filter dropdowns.
+   */
+  providers: publicProcedure.query(async () => {
+    const rows = await db
+      .selectDistinct({ providerId: trustScore.providerId })
+      .from(trustScore)
+      .orderBy(trustScore.providerId);
+
+    return { providers: rows.map((r) => r.providerId) };
+  }),
 });


### PR DESCRIPTION
## What

Adds missing tRPC endpoints to support the trust score leaderboard and detail pages from #43.

### Changes to :

1. **Provider filter on ** — optional  param filters the leaderboard by provider ID
2. ** query** — returns  data for a model over N days, powers the score history chart on 
3. ** query** — returns distinct provider IDs with trust scores, for leaderboard filter dropdowns

### Part of #43 acceptance criteria:
- ✅ Model detail page shows dimensional breakdown (already via )
- ✅ Score history snapshots queryable for chart data
- ✅ Filter by provider on leaderboard

## Scope
**One file only** — the tRPC router. No UI, no jobs, no ingestion. Keeping PRs small per team rules.