### PR TITLE
ci: migrate GitHub Actions to Node.js 24 (#125)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     name: ESLint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npm run lint
@@ -23,10 +23,10 @@ jobs:
     name: TypeScript Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npx tsc --noEmit
@@ -36,10 +36,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, typecheck]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npm run build
@@ -48,12 +48,10 @@ jobs:
     name: Security Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npm audit --audit-level=high
-
-

--- a/.github/workflows/update-cli-models.yml
+++ b/.github/workflows/update-cli-models.yml
@@ -5,6 +5,10 @@ on:
     - cron: "0 6 * * 1" # Every Monday at 6 AM UTC
   workflow_dispatch: # Allow manual trigger
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-models:
     runs-on: ubuntu-latest
@@ -12,11 +16,11 @@ jobs:
       run:
         working-directory: packages/cli
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install dependencies
         run: npm ci
@@ -35,7 +39,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.changes.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore(cli): update model pricing and capabilities"


### PR DESCRIPTION
## Changes

Migrates all GitHub Actions workflows to Node.js 24 ahead of the June 2, 2026 deprecation deadline.

### Action version bumps
- `actions/checkout` v4 → v6
- `actions/setup-node` v4 → v6
- `peter-evans/create-pull-request` v6 → v8

### Other changes
- Node.js runtime: 20 → 24
- Added explicit permissions to `update-cli-models.yml` (fixes #132 — scheduled workflow was failing with 403)

## Testing
- CI should pass on this PR with the new action versions
- Scheduled workflow can be manually triggered after merge to verify

Closes #125
Closes #132

— Sarah (DevOps)
