### PR TITLE
fix(#170): Add Stripe price ID validation — fail fast in production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,9 +22,11 @@ STRIPE_WEBHOOK_SECRET=whsec_placeholder
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_placeholder
 
 # Stripe — Price IDs (from Stripe Dashboard → Products)
-STRIPE_PRICE_PRO=price_pro_placeholder
+# See docs/MONETIZATION.md §4.2 for product setup instructions
+# Pro: $19/mo, $182/yr (~20% off) | Team: $49/mo, $470/yr (~20% off)
+STRIPE_PRICE_PRO_MONTHLY=price_pro_monthly_placeholder
 STRIPE_PRICE_PRO_ANNUAL=price_pro_annual_placeholder
-STRIPE_PRICE_TEAM=price_team_placeholder
+STRIPE_PRICE_TEAM_MONTHLY=price_team_monthly_placeholder
 STRIPE_PRICE_TEAM_ANNUAL=price_team_annual_placeholder
 
 # Clerk — Secret key (for legacy/migration auth)

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -10,6 +10,41 @@ export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY ?? "sk_test_place
 });
 
 // ============================================
+// Placeholder Detection & Config Validation
+// ============================================
+
+const PLACEHOLDER_PATTERNS = ["placeholder", "price_pro_", "price_team_", "price_extra_"];
+
+function isPlaceholderPriceId(priceId: string | undefined): boolean {
+  if (!priceId) return true;
+  return PLACEHOLDER_PATTERNS.some((pattern) => priceId.toLowerCase().includes(pattern));
+}
+
+/**
+ * Validate that all required Stripe price IDs are configured.
+ * Throws in production if placeholders are detected.
+ * Call this at checkout time to fail fast with a clear error.
+ */
+export function validateStripeConfig(): { valid: boolean; missing: string[] } {
+  const missing: string[] = [];
+  const isProd = process.env.NODE_ENV === "production";
+
+  if (isPlaceholderPriceId(process.env.STRIPE_PRICE_PRO_MONTHLY)) missing.push("STRIPE_PRICE_PRO_MONTHLY");
+  if (isPlaceholderPriceId(process.env.STRIPE_PRICE_PRO_ANNUAL)) missing.push("STRIPE_PRICE_PRO_ANNUAL");
+  if (isPlaceholderPriceId(process.env.STRIPE_PRICE_TEAM_MONTHLY)) missing.push("STRIPE_PRICE_TEAM_MONTHLY");
+  if (isPlaceholderPriceId(process.env.STRIPE_PRICE_TEAM_ANNUAL)) missing.push("STRIPE_PRICE_TEAM_ANNUAL");
+
+  if (isProd && missing.length > 0) {
+    throw new Error(
+      `[STRIPE CONFIG ERROR] Production missing real Stripe price IDs: ${missing.join(", ")}. ` +
+      `Create products in Stripe Dashboard, set env vars. See docs/MONETIZATION.md §4.2.`
+    );
+  }
+
+  return { valid: missing.length === 0, missing };
+}
+
+// ============================================
 // Plan Pricing — Price IDs via env vars, amounts for display
 // ============================================
 
@@ -63,10 +98,19 @@ export type PlanKey = keyof typeof PLANS;
 export type BillingInterval = "month" | "year";
 
 /**
- * Get the Stripe price ID for a plan + interval combination
+ * Get the Stripe price ID for a plan + interval combination.
+ * Throws if the price ID is a placeholder (safety check).
  */
 export function getPriceId(plan: PlanKey, interval: BillingInterval): string {
-  return PLANS[plan][interval === "year" ? "annual" : "monthly"].priceId;
+  const priceId = PLANS[plan][interval === "year" ? "annual" : "monthly"].priceId;
+  if (isPlaceholderPriceId(priceId)) {
+    throw new Error(
+      `Stripe price ID for ${plan}/${interval} is a placeholder. ` +
+      `Set STRIPE_PRICE_${plan.toUpperCase()}_${interval === "year" ? "ANNUAL" : "MONTHLY"} env var. ` +
+      `See docs/MONETIZATION.md §4.2.`
+    );
+  }
+  return priceId;
 }
 
 // ============================================
@@ -74,10 +118,10 @@ export function getPriceId(plan: PlanKey, interval: BillingInterval): string {
 // ============================================
 
 /**
- * Get price ID for a plan + interval combination
+ * Get price ID for a plan + interval combination (alias for getPriceId with validation)
  */
 export function getPlanPriceId(plan: PlanKey, interval: BillingInterval): string {
-  return PLANS[plan][interval === "year" ? "annual" : "monthly"].priceId;
+  return getPriceId(plan, interval);
 }
 
 /**

--- a/src/server/api/routers/billing.ts
+++ b/src/server/api/routers/billing.ts
@@ -10,6 +10,7 @@ import {
   createPortalSession,
   createStripeCustomer,
   getPlanPriceId,
+  validateStripeConfig,
   PLANS,
   type PlanKey,
   type BillingInterval,
@@ -133,6 +134,9 @@ export const billingRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
+      // Validate Stripe config — throws in prod if placeholders detected
+      validateStripeConfig();
+
       const plan = PLANS[input.plan as PlanKey];
       if (!plan) {
         throw new TRPCError({
@@ -141,7 +145,15 @@ export const billingRouter = createTRPCRouter({
         });
       }
 
-      const priceId = getPlanPriceId(input.plan as PlanKey, input.interval as BillingInterval);
+      let priceId: string;
+      try {
+        priceId = getPlanPriceId(input.plan as PlanKey, input.interval as BillingInterval);
+      } catch (err) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: err instanceof Error ? err.message : "Stripe configuration error.",
+        });
+      }
 
       // Get or create subscription record (with Stripe customer)
       const [existingSub] = await db
@@ -249,6 +261,9 @@ export const billingRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
+      // Validate Stripe config — throws in prod if placeholders detected
+      validateStripeConfig();
+
       const [sub] = await db
         .select()
         .from(subscription)
@@ -277,9 +292,17 @@ export const billingRouter = createTRPCRouter({
         });
       }
 
-      // Get the new price ID
+      // Get the new price ID (with placeholder safety check)
       const planKey = sub.tier as PlanKey;
-      const priceId = getPlanPriceId(planKey, newInterval);
+      let priceId: string;
+      try {
+        priceId = getPlanPriceId(planKey, newInterval);
+      } catch (err) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: err instanceof Error ? err.message : "Stripe configuration error.",
+        });
+      }
 
       // Update the Stripe subscription — proration is automatic
       const stripeSubscription = await stripe.subscriptions.retrieve(


### PR DESCRIPTION
## Fix for #170: Stripe Price IDs Are Placeholders

### Problem
Stripe price IDs had placeholder fallbacks with no production validation. If env vars weren't set, checkout would fail with a cryptic Stripe API error instead of a clear config error.

### Changes
- **src/lib/stripe.ts**: Added `validateStripeConfig()` and `isPlaceholderPriceId()` — detects placeholder patterns and throws in production with actionable error messages. `getPriceId()`/`getPlanPriceId()` now validate before returning.
- **src/server/api/routers/billing.ts**: Added `validateStripeConfig()` call in `createCheckout` and `switchInterval` mutations. Wrapped price ID lookups in try/catch for proper TRPC error handling.
- **.env.example**: Fixed env var names to match actual code. Added MONETIZATION.md reference.

### What still needs to happen (manual)
1. Create Stripe products in Dashboard (Pro: $19/mo, $182/yr | Team: $49/mo, $470/yr)
2. Set env vars in Vercel/production (STRIPE_PRICE_PRO_MONTHLY, etc.)
3. Test checkout flow end-to-end

### Testing
- TypeScript compilation passes
- Next.js build passes
- Pre-push checks pass

Closes #170