### PR TITLE
fix(models): revert models.list to publicProcedure — fixes #242

### DIFF
--- a/agents/state/devfix.json
+++ b/agents/state/devfix.json
@@ -1,7 +1,7 @@
 {
   "agent": "aaron",
   "role": "Dev Fix",
-  "lastSession": "2026-03-16T07:28:00+01:00",
+  "lastSession": "2026-03-16T16:21:00+01:00",
   "completedWork": [
     {
       "pr": 53,
@@ -18,6 +18,14 @@
       "status": "fixed",
       "fixedAt": "2026-03-16T07:28:00+01:00",
       "summary": "Fixed TypeScript CI failures on PR #101 (fix/37-pricing-mismatch) caused by bad rebase. Removed duplicated handleSubscriptionDeleted with undefined references (getTierFromPriceId, getCurrentPeriodEnd, logger) in route.ts. Fixed billingInterval → interval column name mismatch in billing.ts. TypeScript, ESLint, and Security Audit all passing."
+    },
+    {
+      "pr": 243,
+      "issue": 242,
+      "title": "Fix models page — revert models.list to publicProcedure",
+      "status": "open",
+      "openedAt": "2026-03-16T16:21:00+01:00",
+      "summary": "Critical fix: models.list was changed from publicProcedure to usageEnforcedProcedure (extends protectedProcedure) in commit 42ada72, breaking the /models page for all unauthenticated users. Reverted to publicProcedure. Model browsing is a public operation. Build passes."
     }
   ]
 }

--- a/src/server/api/routers/models.ts
+++ b/src/server/api/routers/models.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { createTRPCRouter, publicProcedure, protectedProcedure, usageEnforcedProcedure } from "../trpc";
+import { createTRPCRouter, publicProcedure, protectedProcedure } from "../trpc";
 import { db } from "../../db";
 import { model, review } from "../../db/schema";
 import { eq, and, desc, asc, sql, ilike, or } from "drizzle-orm";
@@ -22,7 +22,7 @@ export const modelsRouter = createTRPCRouter({
   // ============================================
   // LIST — Discovery endpoint with advanced filters
   // ============================================
-  list: usageEnforcedProcedure
+  list: publicProcedure
     .input(
       z.object({
         category: z.string().optional(),


### PR DESCRIPTION
## 🚨 Critical Fix: Failed to load models on /models page

**Reported:** 16:18 CET by Michel — users see "Failed to load models" on production.

### Root Cause

Commit `42ada72` (wiring `usageEnforcedProcedure` for #69) changed `models.list` from `publicProcedure` to `usageEnforcedProcedure`.

The problem: `usageEnforcedProcedure` extends `protectedProcedure`, which requires authentication. The `/models` page is a **public browsing page** — users shouldn't need to be logged in just to discover models.

### Fix

Revert `models.list` back to `publicProcedure`.

Model browsing is a public operation that doesn't consume API usage credits. Usage enforcement should only apply to authenticated API endpoints that actually meter usage (like `trust-scores`).

### Changes

- `src/server/api/routers/models.ts`: `usageEnforcedProcedure` → `publicProcedure`

### Verification

- ✅ Build passes (TypeScript, ESLint, Security Audit all green)
- ✅ Pre-push hooks passed

---
— Aaron (Dev Fix) #242
